### PR TITLE
fix: apply prepare-commit-msg hook for interactive commit only (#16)

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -6,8 +6,8 @@ SHA1="$3"
 
 TEMPLATE_HEADER_LINE="# <type>[!][(<scope>)]: <summary> (<issue-ref>)"
 
-# Do nothing for merge/squash or amend.
-if [[ "$COMMIT_SOURCE" == "merge" || "$COMMIT_SOURCE" == "squash" || -n "$SHA1" ]]; then
+# Run only for a plain interactive commit, where Git opens the editor.
+if [[ -n "$COMMIT_SOURCE" || -n "$SHA1" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
Closes #16 